### PR TITLE
Feedback

### DIFF
--- a/appendo/appendo.ml
+++ b/appendo/appendo.ml
@@ -17,7 +17,7 @@ module Helper = struct
     let run_list n result = 
       print_results n result show_logic_int_list reify_list 
   end 
-  
+(*  
 let rec appendo xs ys out = ocanren (
     xs == [] & ys == out | 
     fresh h, t, r in 
@@ -25,10 +25,10 @@ let rec appendo xs ys out = ocanren (
       (appendo t ys r) & 
       h :: r == out   
   ) 
- 
+ *)
 (* File "appendo.ml", line 37, characters 14-16:
    Parse error: ')' expected after [ocanren_expr] (in [ocanren_embedding]) *)
-(*
+
 let rec appendo xs ys out = ocanren (
     xs == [] & ys == out | 
     fresh h, t, r in 
@@ -36,7 +36,6 @@ let rec appendo xs ys out = ocanren (
       appendo t ys r & 
       h :: r == out   
   )
-*)
  
 let _ =                       
   Helper.run_list 1 @@ 

--- a/peval/peval.ml
+++ b/peval/peval.ml
@@ -19,34 +19,43 @@ module Simple =
     let disj x y = inj @@ F.distrib (Disj (x, y))
     let var  x   = inj @@ F.distrib (Var x)
 
-    let rec evalo st fm =
+    let rec evalo st fm = ocanren (
+      fresh x, y, v in
+      || (
+          fm == Conj (x, y) &  evalo st x & evalo st y;
+          fm == Disj (x, y) & (evalo st x | evalo st y);
+          fm == Var  (v)    & Std.List.membero st v
+        )
+    )
+
+    (*let rec evalo st fm =
       fresh (x y v) (
         conde [
           fm === conj x y &&& evalo st x &&& evalo st y;
           fm === disj x y &&& (evalo st x ||| evalo st y);
           fm === var  v   &&& Std.List.membero st v
       ])
-    
+     *)
     (* File "peval.ml", line 35, characters 24-25:
        Parse error: ',' or ')' expected (in [ocanren_term']) *)
-    (*
-    let rec evalo fm = ocanren (
+    
+    let rec evalo' fm = ocanren (
          fresh x, y in 
-           fm == (conj x y)
+           fm == Conj (x, y)
        )
-    *)
+    
       
     (* File "peval.ml", line 47, characters 11-21:
        Error: This function has type
                 ('a, 'b Logic.logic) Logic.injected ->
                 ('a, 'b Logic.logic) Logic.injected -> OCanren.goal
               It is applied to too many arguments; maybe you forgot a `;'. *)
-    (*  
-    let rec evalo fm = ocanren (
+      
+    let rec evalo'' fm = ocanren (
          fresh x, y in 
-           fm == conj x y
+           fm == !(conj x y)
        )
-   *)
+   
     
     let _ =
       Printf.printf "%d\n" @@
@@ -73,77 +82,55 @@ module Elaborated =
     | FFalse 
     with show, gmap
 
-    @type name = [ `x | `y | `z ] with show, gmap
-
-    @type f = (f, name logic) fa logic with show, gmap
+    @type name   = X | Y | Z with show, gmap
+    @type f      = (f, name logic) fa logic with show, gmap
+    @type answer = ocanren ((name * bool) list) with show
 
     module F = Fmap2 (struct type ('a, 'b) t = ('a, 'b) fa let fmap f g x = gmap(fa) f g x end)
 
     let rec reify_f f = F.reify reify_f reify f
                   
-    let conj x y = inj @@ F.distrib (Conj (x, y))
-    let disj x y = inj @@ F.distrib (Disj (x, y))
-    let var  x   = inj @@ F.distrib (Var x)
-    let neg  x   = inj @@ F.distrib (Neg x)
-    let ftrue () = inj @@ F.distrib FTrue 
-    let ffalse () = inj @@ F.distrib FFalse
+    let conj   x y = inj @@ F.distrib (Conj (x, y))
+    let disj   x y = inj @@ F.distrib (Disj (x, y))
+    let var    x   = inj @@ F.distrib (Var x)
+    let neg    x   = inj @@ F.distrib (Neg x)
+    let fTrue  ()  = inj @@ F.distrib FTrue 
+    let fFalse ()  = inj @@ F.distrib FFalse
 
+    let x () = !! X
+    let y () = !! Y
+    let z () = !! Z
+             
     open List
-    
-    let show_env c = show(list) (show(pair) (show(name)) string_of_bool) c       
-        
-    let rec evalo st fm u = 
-      fresh (x y z v w) (
-        conde [
-          fm === conj x y  &&& evalo st x v &&& evalo st y w &&& Std.Bool.ando v w u ;
-          fm === disj x y  &&& evalo st x v &&& evalo st y w &&& Std.Bool.oro  v w u ;
-          fm === neg  x    &&& evalo st x v &&& Std.Bool.noto v u ;
-          fm === var  z    &&& Std.List.assoco z st u ; 
-          fm === ftrue ()  &&& (Std.Bool.truo === u) ; 
-          fm === ffalse () &&& (Std.Bool.falso === u)
-  
-        ])
- 
-    (* File "peval.ml", line 121, characters 31-44:
-       Error: This expression has type
-                OCanren.Std.Bool.groundi =
-                  (OCanren.Std.Bool.ground, OCanren.Std.Bool.logic) Logic.injected
-              but an expression was expected of type
-                OCanren.goal = OCanren.State.t RStream.t Core.goal' *)
-    (*
-    let rec evalo st fm u = 
-      fresh (x y z v w) (
-        conde [
-          fm === conj x y  &&& evalo st x v &&& evalo st y w &&& Std.Bool.ando v w u ;
-          fm === disj x y  &&& evalo st x v &&& evalo st y w &&& Std.Bool.oro  v w u ;
-          fm === neg  x    &&& evalo st x v &&& Std.Bool.noto v u ;
-          fm === var  z    &&& Std.List.assoco z st u ; 
-          fm === ftrue ()  &&& Std.Bool.truo === u ; 
-          fm === ffalse () &&& Std.Bool.falso === u 
-        ])
-    *)
 
+    let rec evalo st fm u = ocanren (
+      fresh x, y, z, v, w in
+      || (
+          fm == Conj (x, y) & evalo st x v & evalo st y w & Std.Bool.ando v w u;
+          fm == Disj (x, y) & evalo st x v & evalo st y w & Std.Bool.oro  v w u;
+          fm == Neg  (x)    & evalo st x v & Std.Bool.noto v u;
+          fm == Var  (z)    & Std.List.assoco z st u; 
+          fm == FTrue       & true  == u; 
+          fm == FFalse      & false == u 
+      )
+    )
+      
     let runTest strRepr query = 
       Printf.printf "\n%s\n\n" strRepr;
-      List.iter (fun s ->
-          Printf.printf "%s\n" @@ show(Std.List.logic)
-                                    (show(Std.Pair.logic)
-                                       (show(logic) (show(name)))
-                                       (show(logic) (show(bool)))
-                                    )
-                                  
-                                    (s#reify (Std.List.reify (Std.Pair.reify reify reify)))) @@ RStream.take ~n:10 @@
+      List.iter (fun s -> Printf.printf "%s\n" @@ show(answer) 
+                                                    (s#reify (Std.List.reify (Std.Pair.reify reify reify)))
+                ) @@ RStream.take ~n:10 @@
       query (fun st -> st)
 
     let _ =
       runTest "Conj (Neg `x) `y:" @@  
-        run q (fun st -> evalo st (conj (neg @@ var !!`x) (var !!`y)) !!true); 
+        run q (fun st -> ocanren (evalo st Conj (Neg (Var (X)), Var (Y)) true)); 
       runTest "True:" @@  
-        run q (fun st -> evalo st (ftrue ()) !!true);
+        run q (fun st -> ocanren (evalo st FTrue true)); 
       runTest "False (evaluates to true):" @@  
-        run q (fun st -> evalo st (ffalse ()) !!true);
+        run q (fun st -> ocanren (evalo st FFalse true)); 
       runTest "False: (evaluates to false):" @@  
-        run q (fun st -> evalo st (ffalse ()) !!false)
+        run q (fun st -> ocanren (evalo st FFalse false)) 
         
   end
     


### PR DESCRIPTION
Fixed some issues in OCanren's syntax extension (an update is needed). 

In expressions

&&& smth === smth

the priority of "&&&" is higher than that for "===", and all infixes are left-associative, hence typing error in appendo.ml. This behavior is hardcoded in OCaml and can not be fixed.